### PR TITLE
Remove unnecessary call to `list()`

### DIFF
--- a/deque.py
+++ b/deque.py
@@ -155,7 +155,7 @@ if __name__ == '__main__':
             elif word == 'exit':
                 exit(0)
             elif word == 'trace':
-                print(''.join(list(map(lambda x: '*' if x == 1 else ' ', data))))
+                print(''.join(map(lambda x: '*' if x == 1 else ' ', data)))
                 ip += 1
             else:
                 try:


### PR DESCRIPTION
`str.join()` supports generators, so the explicit conversion to a list is useless.