### PR TITLE
Split words using any whitespaces

### DIFF
--- a/deque.py
+++ b/deque.py
@@ -16,8 +16,7 @@ if __name__ == '__main__':
         program = [word
                    for line in f.read().splitlines()
                    if not line.lstrip().startswith('#')
-                   for word in line.split(' ')
-                   if len(word) > 0]
+                   for word in line.split()]
 
         labels = {}
         for ip in range(len(program)):


### PR DESCRIPTION
Until now, words had to be separated by spaces only. Now, tabs (or any whitespaces work too). In addition, the code is a little bit cleaner because when using `str.split()` without any arguments, any empty strings are removed, thus rendering the `len(word) > 0` condition unecessary.